### PR TITLE
add external_id parameter to bulk upsert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+ruby "2.3.0"
 
 # Specify your gem's dependencies in restforce-bulk.gemspec
 gemspec

--- a/lib/restforce/bulk/builder/xml.rb
+++ b/lib/restforce/bulk/builder/xml.rb
@@ -8,10 +8,12 @@ module Restforce
           self.operation = operation
         end
 
-        def job(object_name, content_type)
+        def job(object_name, content_type, external_id_field=nil, concurrency_mode=nil)
           build_xml(:jobInfo) do |xml|
             xml.operation operation
             xml.object object_name
+            xml.externalIdFieldName external_id_field if external_id_field
+            xml.concurrencyMode concurrency_mode if concurrency_mode
             xml.contentType content_type
           end
         end

--- a/lib/restforce/bulk/job.rb
+++ b/lib/restforce/bulk/job.rb
@@ -11,9 +11,9 @@ module Restforce
       }
 
       class << self
-        def create(operation, object_name, content_type=:xml)
+        def create(operation, object_name, content_type=:xml, external_id_field=nil, concurrency_mode=nil)
           builder  = Restforce::Bulk::Builder::Xml.new(operation)
-          data     = builder.job(object_name, JOB_CONTENT_TYPE_MAPPING[content_type.to_sym])
+          data     = builder.job(object_name, JOB_CONTENT_TYPE_MAPPING[content_type.to_sym], external_id_field, concurrency_mode)
 
           response = Restforce::Bulk.client.perform_request(:post, 'job', data)
 

--- a/lib/restforce/bulk/version.rb
+++ b/lib/restforce/bulk/version.rb
@@ -1,5 +1,5 @@
 module Restforce
   module Bulk
-    VERSION = "0.1.0"
+    VERSION = "0.1.2"
   end
 end

--- a/restforce-bulk.gemspec
+++ b/restforce-bulk.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "restforce", "~> 2.2"
+  spec.add_dependency "restforce", "~> 2.5"
   spec.add_dependency "nokogiri"
   spec.add_dependency "multi_xml"
   spec.add_dependency "activesupport", "~> 4.2.4"

--- a/spec/restforce/bulk/client_spec.rb
+++ b/spec/restforce/bulk/client_spec.rb
@@ -19,7 +19,7 @@ describe Restforce::Bulk::Client do
   end
 
   context "when a client is given" do
-    let(:restforce_client) { Restforce.new(instance_url: 'test.salesforce.com') }
+    let(:restforce_client) { Restforce.new(instance_url: 'https://test.salesforce.com') }
 
     it "uses it instead" do
       allow(restforce_client).to receive(:authenticate!)

--- a/spec/restforce/bulk/job_spec.rb
+++ b/spec/restforce/bulk/job_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 describe Restforce::Bulk::Job, mock_restforce: true do
   let(:object_name) { 'Account' }
+  let(:external_id_field) { 'Name' }
 
   let(:raw_response_body) { '' }
 
@@ -19,6 +20,15 @@ describe Restforce::Bulk::Job, mock_restforce: true do
       build_bulk_xml(:jobInfo) do |xml|
         xml.operation operation
         xml.object object_name
+        xml.contentType operation_content_type
+      end
+    end
+
+    let(:xml_upsert) do
+      build_bulk_xml(:jobInfo) do |xml|
+        xml.operation operation
+        xml.object object_name
+        xml.externalIdFieldName external_id_field
         xml.contentType operation_content_type
       end
     end
@@ -76,6 +86,16 @@ describe Restforce::Bulk::Job, mock_restforce: true do
 
         job = Restforce::Bulk::Job.create(operation, object_name, :csv)
         expect(job.content_type).to eq(:csv)
+      end
+    end
+
+    context "with external_id" do
+      let(:operation) { 'upsert' }
+
+      it "adds an external id to xml if there is an external_id" do
+        expect_restforce_request(:post, "job", xml_upsert).and_return(restforce_response)
+
+        job = Restforce::Bulk::Job.create(operation, object_name, :xml, 'Name')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require 'bundler/setup'
 
 Bundler.require
 require 'restforce/bulk'
+require 'securerandom'
 
 ROOT_PATH = File.expand_path('../..', __FILE__)
 
@@ -36,7 +37,7 @@ module RestforceMockHelpers
 
     send(mock_type, restforce_client)
       .to receive(method)
-      .with([bulk_api_base_path, path].join('/'), data, resulting_headers)
+            .with([bulk_api_base_path, path].join('/'), data, resulting_headers)
   end
 
   def allow_restforce_request(method, path, data=nil, content_type=:xml, headers={})


### PR DESCRIPTION
add external_id parameter to bulk upsert
* missing from current gem - merge of existing PR (untouched for 1yr+)
* used in agency integrator story: https://github.com/HealthyWealthy/hiq_salesforce/pull/293